### PR TITLE
Enabling shard migration within lowkiq

### DIFF
--- a/lib/lowkiq.rb
+++ b/lib/lowkiq.rb
@@ -95,6 +95,14 @@ module Lowkiq
         Lowkiq.threads_per_node,
       )
     end
+
+    def evaluate_all_workers
+      self.workers.each do |wrkr|
+        next unless wrkr.prev_shards_count && (wrkr.prev_shards_count != wrkr.shards_count)
+        wrkr.shard_migration
+      end
+    end
+
   end
 
   # defaults
@@ -108,4 +116,5 @@ module Lowkiq
   self.build_scheduler = ->() { Lowkiq.build_lag_scheduler }
   self.build_splitter = ->() { Lowkiq.build_default_splitter }
   self.last_words = ->(ex) {}
+  self.shards_count_changed? = ENV.fetch('SHARDS_COUNT_CHANGED', false)
 end

--- a/lib/lowkiq/server.rb
+++ b/lib/lowkiq/server.rb
@@ -17,6 +17,7 @@ module Lowkiq
     end
 
     def start
+      Lowkiq.evaluate_all_workers if Lowkiq.shards_count_changed?  
       @shard_handlers_by_thread.each do |handlers|
         handlers.each(&:restore)
       end

--- a/lib/lowkiq/worker.rb
+++ b/lib/lowkiq/worker.rb
@@ -3,6 +3,7 @@ module Lowkiq
     extend ExtendTracker
 
     attr_accessor :shards_count,
+                  :prev_shards_count,
                   :batch_size,
                   :max_retry_count,
                   :queue_name,
@@ -38,6 +39,10 @@ module Lowkiq
 
     def perform_async(batch)
       client_queue.push batch
+    end
+
+    def shard_migration
+      client_queue.restore_shard_keys self.prev_shards_count
     end
   end
 end


### PR DESCRIPTION
- In case of shard count change, queue data migration would be handled as part of the intialization of lowkiq server.
- User has to change the shard count and prev shard count of the worker and then during lowkiq server start, set the env variable(self.shards_count_changed?) to do the shard migration.