### PR TITLE
add a retries exhausted method for worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ module ATestWorker
     10 * (count + 1) # (i.e. 10, 20, 30, 40, 50)
   end
 
+  def self.retries_exhausted(batch)
+    batch.each do |job|
+      Rails.logger.info "retries exhausted for #{name} with error #{job[:error]}"
+    end
+  end
+
   def self.perform(payloads_by_id)
     # payloads_by_id is a hash map
     payloads_by_id.each do |id, payloads|

--- a/lib/lowkiq/shard_handler.rb
+++ b/lib/lowkiq/shard_handler.rb
@@ -39,6 +39,7 @@ module Lowkiq
 
         @queue.push_back back
         @queue.push_to_morgue morgue
+        @worker.retries_exhausted morgue
         @queue.ack @shard_index, data, :fail
         false
       end

--- a/lib/lowkiq/shard_handler.rb
+++ b/lib/lowkiq/shard_handler.rb
@@ -39,8 +39,8 @@ module Lowkiq
 
         @queue.push_back back
         @queue.push_to_morgue morgue
-        @worker.retries_exhausted morgue
         @queue.ack @shard_index, data, :fail
+        @worker.retries_exhausted morgue
         false
       end
     end

--- a/lib/lowkiq/worker.rb
+++ b/lib/lowkiq/worker.rb
@@ -18,6 +18,10 @@ module Lowkiq
       (retry_count ** 4) + 15 + (rand(30) * (retry_count + 1))
     end
 
+    def retries_exhausted(batch)
+      # no-op
+    end
+
     def perform(payload)
       fail "not implemented"
     end


### PR DESCRIPTION
Adding a default (no-op'ed) `retries_exhausted` method on `Lowkiq::Worker` class. It can be useful to add meaningful logs, stats push when a worker fails and goes to morgue. If the approach is fine, will add tests.