### PR TITLE
add client-side middleware in worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,8 @@ Options and their default values are:
 + `Lowkiq.redis = ->() { Redis.new url: ENV.fetch('REDIS_URL') }` - redis connection options
 + `Lowkiq.client_pool_size = 5` - redis pool size for queueing jobs
 + `Lowkiq.pool_timeout = 5` - client and server redis pool timeout
-+ `Lowkiq.server_middlewares = []` - a middleware list, used for worker wrapping
++ `Lowkiq.server_middlewares = []` - a middleware list, used when job is processed
++ `Lowkiq.client_middlewares = []` - a middleware list, used when job is enqueued
 + `Lowkiq.on_server_init = ->() {}` - a lambda is being executed when server inits
 + `Lowkiq.build_scheduler = ->() { Lowkiq.build_lag_scheduler }` is a scheduler
 + `Lowkiq.build_splitter = ->() { Lowkiq.build_default_splitter }` is a splitter
@@ -322,6 +323,13 @@ Lowkiq.server_middlewares << -> (worker, batch, &block) do
     raise e
   end
 end
+
+Lowkiq.client_middlewares << -> (worker, batch, &block) do
+  $logger.info "Enqueueing job for #{worker} #{batch}"
+  block.call
+  $logger.info "Enqueued job for #{worker} #{batch}"
+end
+
 ```
 
 ## Performance

--- a/lib/lowkiq.rb
+++ b/lib/lowkiq.rb
@@ -38,7 +38,7 @@ module Lowkiq
   class << self
     attr_accessor :poll_interval, :threads_per_node,
                   :redis, :client_pool_size, :pool_timeout,
-                  :server_middlewares, :on_server_init,
+                  :server_middlewares, :client_middlewares, :on_server_init,
                   :build_scheduler, :build_splitter,
                   :last_words,
                   :dump_payload, :load_payload,
@@ -103,6 +103,7 @@ module Lowkiq
   self.client_pool_size = 5
   self.pool_timeout = 5
   self.server_middlewares = []
+  self.client_middlewares = []
   self.on_server_init = ->() {}
   self.build_scheduler = ->() { Lowkiq.build_lag_scheduler }
   self.build_splitter = ->() { Lowkiq.build_default_splitter }

--- a/lib/lowkiq/worker.rb
+++ b/lib/lowkiq/worker.rb
@@ -38,21 +38,8 @@ module Lowkiq
       Queue::Actions.new client_queue, client_queries
     end
 
-    def client_wrapper
-      null = -> (worker, batch, &block) { block.call }
-      Lowkiq.client_middlewares.reduce(null) do |wrapper, m|
-        -> (worker, batch, &block) do
-          wrapper.call worker, batch do
-            m.call worker, batch, &block
-          end
-        end
-      end
-    end
-
     def perform_async(batch)
-      worker = self
-      wrapper = client_wrapper
-      wrapper.call(worker, batch) {client_queue.push batch}
+      Lowkiq.client_wrapper.call(self, batch) {client_queue.push batch}
     end
 
   end


### PR DESCRIPTION
Adding a client_middleware array on Lowkiq module. It can be useful to add client-side middlewares (i.e: Loggers, Opentelemetry tracer, etc.) 

We construct a Lamda method with those middlewares present in the client_middleware array. (Please check client_wrapper method in Lowkiq.rb)

The client_wrapper wraps around the perform_async method in Lowkiq::Worker module and executes all the middlewares everytime a job is enqueued with perform_async method.

This implementation is similar to the existing server_wrapper method in Lowkiq.rb.